### PR TITLE
fix(lib-dynamodb): use more readable keynode format

### DIFF
--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.spec.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.spec.ts
@@ -1,13 +1,13 @@
 import { Handler, MiddlewareStack } from "@smithy/types";
 
-import { KeyNode } from "../commands/utils";
+import { KeyNodeChildren } from "../commands/utils";
 import { DynamoDBDocumentClientCommand } from "./DynamoDBDocumentClientCommand";
 
 class AnyCommand extends DynamoDBDocumentClientCommand<{}, {}, {}, {}, {}> {
   public middlewareStack: MiddlewareStack<{}, {}>;
   public input: {};
-  protected inputKeyNodes: KeyNode[] = [];
-  protected outputKeyNodes: KeyNode[] = [];
+  protected inputKeyNodes: KeyNodeChildren = {};
+  protected outputKeyNodes: KeyNodeChildren = {};
 
   public argCaptor: [Function, object][] = [];
 

--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
@@ -10,7 +10,7 @@ import {
   MiddlewareStack,
 } from "@smithy/types";
 
-import { KeyNode, marshallInput, unmarshallOutput } from "../commands/utils";
+import { KeyNodeChildren, marshallInput, unmarshallOutput } from "../commands/utils";
 import { DynamoDBDocumentClientResolvedConfig } from "../DynamoDBDocumentClient";
 
 // /** @public */
@@ -29,8 +29,8 @@ export abstract class DynamoDBDocumentClientCommand<
   BaseOutput extends object,
   ResolvedClientConfiguration
 > extends $Command<Input | BaseInput, Output | BaseOutput, ResolvedClientConfiguration> {
-  protected abstract readonly inputKeyNodes: KeyNode[];
-  protected abstract readonly outputKeyNodes: KeyNode[];
+  protected abstract readonly inputKeyNodes: KeyNodeChildren;
+  protected abstract readonly outputKeyNodes: KeyNodeChildren;
   protected abstract clientCommand: $Command<Input | BaseInput, Output | BaseOutput, ResolvedClientConfiguration>;
 
   public abstract middlewareStack: MiddlewareStack<Input | BaseInput, Output | BaseOutput>;

--- a/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
@@ -11,6 +11,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_MEMBERS, ALL_VALUES } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -58,41 +59,23 @@ export class BatchExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   __BatchExecuteStatementCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "Statements",
-      children: {
-        children: [
-          {
-            key: "Parameters",
-            children: {}, // set/list of AttributeValue
-          },
-        ],
+  protected readonly inputKeyNodes = {
+    Statements: {
+      "*": {
+        Parameters: ALL_MEMBERS, // set/list of AttributeValue
       },
     },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "Responses",
-      children: {
-        children: [
-          {
-            key: "Error",
-            children: [
-              {
-                key: "Item",
-                children: {}, // map with AttributeValue
-              },
-            ],
-          },
-          {
-            key: "Item",
-            children: {}, // map with AttributeValue
-          },
-        ],
+  };
+  protected readonly outputKeyNodes = {
+    Responses: {
+      "*": {
+        Error: {
+          Item: ALL_VALUES, // map with AttributeValue
+        },
+        Item: ALL_VALUES, // map with AttributeValue
       },
     },
-  ];
+  };
 
   protected readonly clientCommand: __BatchExecuteStatementCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
@@ -9,6 +9,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_VALUES } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -60,44 +61,29 @@ export class BatchGetCommand extends DynamoDBDocumentClientCommand<
   __BatchGetItemCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "RequestItems",
-      children: {
-        children: [
-          {
-            key: "Keys",
-            children: {
-              children: {}, // map with AttributeValue
-            },
-          },
-        ],
-      },
-    },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "Responses",
-      children: {
-        children: {
-          children: {}, // map with AttributeValue
+  protected readonly inputKeyNodes = {
+    RequestItems: {
+      "*": {
+        Keys: {
+          "*": ALL_VALUES, // map with AttributeValue
         },
       },
     },
-    {
-      key: "UnprocessedKeys",
-      children: {
-        children: [
-          {
-            key: "Keys",
-            children: {
-              children: {}, // map with AttributeValue
-            },
-          },
-        ],
+  };
+  protected readonly outputKeyNodes = {
+    Responses: {
+      "*": {
+        "*": ALL_VALUES, // map with AttributeValue
       },
     },
-  ];
+    UnprocessedKeys: {
+      "*": {
+        Keys: {
+          "*": ALL_VALUES, // map with AttributeValue
+        },
+      },
+    },
+  };
 
   protected readonly clientCommand: __BatchGetItemCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
@@ -12,6 +12,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_VALUES } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -81,77 +82,41 @@ export class BatchWriteCommand extends DynamoDBDocumentClientCommand<
   __BatchWriteItemCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "RequestItems",
-      children: {
-        children: {
-          children: [
-            {
-              key: "PutRequest",
-              children: [
-                {
-                  key: "Item",
-                  children: {}, // map with AttributeValue
-                },
-              ],
-            },
-            {
-              key: "DeleteRequest",
-              children: [
-                {
-                  key: "Key",
-                  children: {}, // map with AttributeValue
-                },
-              ],
-            },
-          ],
+  protected readonly inputKeyNodes = {
+    RequestItems: {
+      "*": {
+        "*": {
+          PutRequest: {
+            Item: ALL_VALUES, // map with AttributeValue
+          },
+          DeleteRequest: {
+            Key: ALL_VALUES, // map with AttributeValue
+          },
         },
       },
     },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "UnprocessedItems",
-      children: {
-        children: {
-          children: [
-            {
-              key: "PutRequest",
-              children: [
-                {
-                  key: "Item",
-                  children: {}, // map with AttributeValue
-                },
-              ],
-            },
-            {
-              key: "DeleteRequest",
-              children: [
-                {
-                  key: "Key",
-                  children: {}, // map with AttributeValue
-                },
-              ],
-            },
-          ],
+  };
+  protected readonly outputKeyNodes = {
+    UnprocessedItems: {
+      "*": {
+        "*": {
+          PutRequest: {
+            Item: ALL_VALUES, // map with AttributeValue
+          },
+          DeleteRequest: {
+            Key: ALL_VALUES, // map with AttributeValue
+          },
         },
       },
     },
-    {
-      key: "ItemCollectionMetrics",
-      children: {
-        children: {
-          children: [
-            {
-              key: "ItemCollectionKey",
-              children: {}, // map with AttributeValue
-            },
-          ],
+    ItemCollectionMetrics: {
+      "*": {
+        "*": {
+          ItemCollectionKey: ALL_VALUES, // map with AttributeValue
         },
       },
     },
-  ];
+  };
 
   protected readonly clientCommand: __BatchWriteItemCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/DeleteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/DeleteCommand.ts
@@ -10,6 +10,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_MEMBERS, ALL_VALUES, SELF } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -59,43 +60,22 @@ export class DeleteCommand extends DynamoDBDocumentClientCommand<
   __DeleteItemCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "Key",
-      children: {}, // map with AttributeValue
-    },
-    {
-      key: "Expected",
-      children: {
-        children: [
-          { key: "Value" },
-          {
-            key: "AttributeValueList",
-            children: {}, // set/list of AttributeValue
-          },
-        ],
+  protected readonly inputKeyNodes = {
+    Key: ALL_VALUES, // map with AttributeValue
+    Expected: {
+      "*": {
+        Value: SELF,
+        AttributeValueList: ALL_MEMBERS, // set/list of AttributeValue
       },
     },
-    {
-      key: "ExpressionAttributeValues",
-      children: {}, // map with AttributeValue
+    ExpressionAttributeValues: ALL_VALUES, // map with AttributeValue
+  };
+  protected readonly outputKeyNodes = {
+    Attributes: ALL_VALUES, // map with AttributeValue
+    ItemCollectionMetrics: {
+      ItemCollectionKey: ALL_VALUES, // map with AttributeValue
     },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "Attributes",
-      children: {}, // map with AttributeValue
-    },
-    {
-      key: "ItemCollectionMetrics",
-      children: [
-        {
-          key: "ItemCollectionKey",
-          children: {}, // map with AttributeValue
-        },
-      ],
-    },
-  ];
+  };
 
   protected readonly clientCommand: __DeleteItemCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
@@ -8,6 +8,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_MEMBERS, ALL_VALUES } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -47,24 +48,15 @@ export class ExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   __ExecuteStatementCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "Parameters",
-      children: {}, // set/list of AttributeValue
+  protected readonly inputKeyNodes = {
+    Parameters: ALL_MEMBERS, // set/list of AttributeValue
+  };
+  protected readonly outputKeyNodes = {
+    Items: {
+      "*": ALL_VALUES, // map with AttributeValue
     },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "Items",
-      children: {
-        children: {}, // map with AttributeValue
-      },
-    },
-    {
-      key: "LastEvaluatedKey",
-      children: {}, // map with AttributeValue
-    },
-  ];
+    LastEvaluatedKey: ALL_VALUES, // map with AttributeValue
+  };
 
   protected readonly clientCommand: __ExecuteStatementCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
@@ -10,6 +10,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_MEMBERS, ALL_VALUES } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -54,32 +55,20 @@ export class ExecuteTransactionCommand extends DynamoDBDocumentClientCommand<
   __ExecuteTransactionCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "TransactStatements",
-      children: {
-        children: [
-          {
-            key: "Parameters",
-            children: {}, // set/list of AttributeValue
-          },
-        ],
+  protected readonly inputKeyNodes = {
+    TransactStatements: {
+      "*": {
+        Parameters: ALL_MEMBERS, // set/list of AttributeValue
       },
     },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "Responses",
-      children: {
-        children: [
-          {
-            key: "Item",
-            children: {}, // map with AttributeValue
-          },
-        ],
+  };
+  protected readonly outputKeyNodes = {
+    Responses: {
+      "*": {
+        Item: ALL_VALUES, // map with AttributeValue
       },
     },
-  ];
+  };
 
   protected readonly clientCommand: __ExecuteTransactionCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/GetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/GetCommand.ts
@@ -8,6 +8,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_VALUES } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -46,18 +47,12 @@ export class GetCommand extends DynamoDBDocumentClientCommand<
   __GetItemCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "Key",
-      children: {}, // map with AttributeValue
-    },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "Item",
-      children: {}, // map with AttributeValue
-    },
-  ];
+  protected readonly inputKeyNodes = {
+    Key: ALL_VALUES, // map with AttributeValue
+  };
+  protected readonly outputKeyNodes = {
+    Item: ALL_VALUES, // map with AttributeValue
+  };
 
   protected readonly clientCommand: __GetItemCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/PutCommand.ts
+++ b/lib/lib-dynamodb/src/commands/PutCommand.ts
@@ -10,6 +10,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_MEMBERS, ALL_VALUES, SELF } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -59,43 +60,22 @@ export class PutCommand extends DynamoDBDocumentClientCommand<
   __PutItemCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "Item",
-      children: {}, // map with AttributeValue
-    },
-    {
-      key: "Expected",
-      children: {
-        children: [
-          { key: "Value" },
-          {
-            key: "AttributeValueList",
-            children: {}, // set/list of AttributeValue
-          },
-        ],
+  protected readonly inputKeyNodes = {
+    Item: ALL_VALUES, // map with AttributeValue
+    Expected: {
+      "*": {
+        Value: SELF,
+        AttributeValueList: ALL_MEMBERS, // set/list of AttributeValue
       },
     },
-    {
-      key: "ExpressionAttributeValues",
-      children: {}, // map with AttributeValue
+    ExpressionAttributeValues: ALL_VALUES, // map with AttributeValue
+  };
+  protected readonly outputKeyNodes = {
+    Attributes: ALL_VALUES, // map with AttributeValue
+    ItemCollectionMetrics: {
+      ItemCollectionKey: ALL_VALUES, // map with AttributeValue
     },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "Attributes",
-      children: {}, // map with AttributeValue
-    },
-    {
-      key: "ItemCollectionMetrics",
-      children: [
-        {
-          key: "ItemCollectionKey",
-          children: {}, // map with AttributeValue
-        },
-      ],
-    },
-  ];
+  };
 
   protected readonly clientCommand: __PutItemCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/QueryCommand.ts
+++ b/lib/lib-dynamodb/src/commands/QueryCommand.ts
@@ -9,6 +9,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_MEMBERS, ALL_VALUES } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -64,50 +65,26 @@ export class QueryCommand extends DynamoDBDocumentClientCommand<
   __QueryCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "KeyConditions",
-      children: {
-        children: [
-          {
-            key: "AttributeValueList",
-            children: {}, // set/list of AttributeValue
-          },
-        ],
+  protected readonly inputKeyNodes = {
+    KeyConditions: {
+      "*": {
+        AttributeValueList: ALL_MEMBERS, // set/list of AttributeValue
       },
     },
-    {
-      key: "QueryFilter",
-      children: {
-        children: [
-          {
-            key: "AttributeValueList",
-            children: {}, // set/list of AttributeValue
-          },
-        ],
+    QueryFilter: {
+      "*": {
+        AttributeValueList: ALL_MEMBERS, // set/list of AttributeValue
       },
     },
-    {
-      key: "ExclusiveStartKey",
-      children: {}, // map with AttributeValue
+    ExclusiveStartKey: ALL_VALUES, // map with AttributeValue
+    ExpressionAttributeValues: ALL_VALUES, // map with AttributeValue
+  };
+  protected readonly outputKeyNodes = {
+    Items: {
+      "*": ALL_VALUES, // map with AttributeValue
     },
-    {
-      key: "ExpressionAttributeValues",
-      children: {}, // map with AttributeValue
-    },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "Items",
-      children: {
-        children: {}, // map with AttributeValue
-      },
-    },
-    {
-      key: "LastEvaluatedKey",
-      children: {}, // map with AttributeValue
-    },
-  ];
+    LastEvaluatedKey: ALL_VALUES, // map with AttributeValue
+  };
 
   protected readonly clientCommand: __QueryCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/ScanCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ScanCommand.ts
@@ -9,6 +9,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_MEMBERS, ALL_VALUES } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -58,39 +59,21 @@ export class ScanCommand extends DynamoDBDocumentClientCommand<
   __ScanCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "ScanFilter",
-      children: {
-        children: [
-          {
-            key: "AttributeValueList",
-            children: {}, // set/list of AttributeValue
-          },
-        ],
+  protected readonly inputKeyNodes = {
+    ScanFilter: {
+      "*": {
+        AttributeValueList: ALL_MEMBERS, // set/list of AttributeValue
       },
     },
-    {
-      key: "ExclusiveStartKey",
-      children: {}, // map with AttributeValue
+    ExclusiveStartKey: ALL_VALUES, // map with AttributeValue
+    ExpressionAttributeValues: ALL_VALUES, // map with AttributeValue
+  };
+  protected readonly outputKeyNodes = {
+    Items: {
+      "*": ALL_VALUES, // map with AttributeValue
     },
-    {
-      key: "ExpressionAttributeValues",
-      children: {}, // map with AttributeValue
-    },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "Items",
-      children: {
-        children: {}, // map with AttributeValue
-      },
-    },
-    {
-      key: "LastEvaluatedKey",
-      children: {}, // map with AttributeValue
-    },
-  ];
+    LastEvaluatedKey: ALL_VALUES, // map with AttributeValue
+  };
 
   protected readonly clientCommand: __ScanCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
@@ -11,6 +11,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_VALUES } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -59,37 +60,22 @@ export class TransactGetCommand extends DynamoDBDocumentClientCommand<
   __TransactGetItemsCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "TransactItems",
-      children: {
-        children: [
-          {
-            key: "Get",
-            children: [
-              {
-                key: "Key",
-                children: {}, // map with AttributeValue
-              },
-            ],
-          },
-        ],
+  protected readonly inputKeyNodes = {
+    TransactItems: {
+      "*": {
+        Get: {
+          Key: ALL_VALUES, // map with AttributeValue
+        },
       },
     },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "Responses",
-      children: {
-        children: [
-          {
-            key: "Item",
-            children: {}, // map with AttributeValue
-          },
-        ],
+  };
+  protected readonly outputKeyNodes = {
+    Responses: {
+      "*": {
+        Item: ALL_VALUES, // map with AttributeValue
       },
     },
-  ];
+  };
 
   protected readonly clientCommand: __TransactGetItemsCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
@@ -14,6 +14,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_VALUES } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -76,82 +77,37 @@ export class TransactWriteCommand extends DynamoDBDocumentClientCommand<
   __TransactWriteItemsCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "TransactItems",
-      children: {
-        children: [
-          {
-            key: "ConditionCheck",
-            children: [
-              {
-                key: "Key",
-                children: {}, // map with AttributeValue
-              },
-              {
-                key: "ExpressionAttributeValues",
-                children: {}, // map with AttributeValue
-              },
-            ],
-          },
-          {
-            key: "Put",
-            children: [
-              {
-                key: "Item",
-                children: {}, // map with AttributeValue
-              },
-              {
-                key: "ExpressionAttributeValues",
-                children: {}, // map with AttributeValue
-              },
-            ],
-          },
-          {
-            key: "Delete",
-            children: [
-              {
-                key: "Key",
-                children: {}, // map with AttributeValue
-              },
-              {
-                key: "ExpressionAttributeValues",
-                children: {}, // map with AttributeValue
-              },
-            ],
-          },
-          {
-            key: "Update",
-            children: [
-              {
-                key: "Key",
-                children: {}, // map with AttributeValue
-              },
-              {
-                key: "ExpressionAttributeValues",
-                children: {}, // map with AttributeValue
-              },
-            ],
-          },
-        ],
-      },
-    },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "ItemCollectionMetrics",
-      children: {
-        children: {
-          children: [
-            {
-              key: "ItemCollectionKey",
-              children: {}, // map with AttributeValue
-            },
-          ],
+  protected readonly inputKeyNodes = {
+    TransactItems: {
+      "*": {
+        ConditionCheck: {
+          Key: ALL_VALUES, // map with AttributeValue
+          ExpressionAttributeValues: ALL_VALUES, // map with AttributeValue
+        },
+        Put: {
+          Item: ALL_VALUES, // map with AttributeValue
+          ExpressionAttributeValues: ALL_VALUES, // map with AttributeValue
+        },
+        Delete: {
+          Key: ALL_VALUES, // map with AttributeValue
+          ExpressionAttributeValues: ALL_VALUES, // map with AttributeValue
+        },
+        Update: {
+          Key: ALL_VALUES, // map with AttributeValue
+          ExpressionAttributeValues: ALL_VALUES, // map with AttributeValue
         },
       },
     },
-  ];
+  };
+  protected readonly outputKeyNodes = {
+    ItemCollectionMetrics: {
+      "*": {
+        "*": {
+          ItemCollectionKey: ALL_VALUES, // map with AttributeValue
+        },
+      },
+    },
+  };
 
   protected readonly clientCommand: __TransactWriteItemsCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/UpdateCommand.ts
+++ b/lib/lib-dynamodb/src/commands/UpdateCommand.ts
@@ -11,6 +11,7 @@ import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 import { Command as $Command } from "@smithy/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@smithy/types";
 
+import { ALL_MEMBERS, ALL_VALUES, SELF } from "../../src/commands/utils";
 import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
@@ -69,49 +70,27 @@ export class UpdateCommand extends DynamoDBDocumentClientCommand<
   __UpdateItemCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  protected readonly inputKeyNodes = [
-    {
-      key: "Key",
-      children: {}, // map with AttributeValue
-    },
-    {
-      key: "AttributeUpdates",
-      children: {
-        children: [{ key: "Value" }],
+  protected readonly inputKeyNodes = {
+    Key: ALL_VALUES, // map with AttributeValue
+    AttributeUpdates: {
+      "*": {
+        Value: SELF,
       },
     },
-    {
-      key: "Expected",
-      children: {
-        children: [
-          { key: "Value" },
-          {
-            key: "AttributeValueList",
-            children: {}, // set/list of AttributeValue
-          },
-        ],
+    Expected: {
+      "*": {
+        Value: SELF,
+        AttributeValueList: ALL_MEMBERS, // set/list of AttributeValue
       },
     },
-    {
-      key: "ExpressionAttributeValues",
-      children: {}, // map with AttributeValue
+    ExpressionAttributeValues: ALL_VALUES, // map with AttributeValue
+  };
+  protected readonly outputKeyNodes = {
+    Attributes: ALL_VALUES, // map with AttributeValue
+    ItemCollectionMetrics: {
+      ItemCollectionKey: ALL_VALUES, // map with AttributeValue
     },
-  ];
-  protected readonly outputKeyNodes = [
-    {
-      key: "Attributes",
-      children: {}, // map with AttributeValue
-    },
-    {
-      key: "ItemCollectionMetrics",
-      children: [
-        {
-          key: "ItemCollectionKey",
-          children: {}, // map with AttributeValue
-        },
-      ],
-    },
-  ];
+  };
 
   protected readonly clientCommand: __UpdateItemCommand;
   public readonly middlewareStack: MiddlewareStack<

--- a/lib/lib-dynamodb/src/commands/marshallInput.spec.ts
+++ b/lib/lib-dynamodb/src/commands/marshallInput.spec.ts
@@ -2,13 +2,13 @@ import { marshallInput } from "./utils";
 
 describe("marshallInput and processObj", () => {
   it("marshallInput should not ignore falsy values", () => {
-    expect(
-      marshallInput({ Items: [0, false, null, ""] }, [{ key: "Items" }], { convertTopLevelContainer: true })
-    ).toEqual({
-      Items: {
-        L: [{ N: "0" }, { BOOL: false }, { NULL: true }, { S: "" }],
-      },
-    });
+    expect(marshallInput({ Items: [0, false, null, ""] }, { Items: null }, { convertTopLevelContainer: true })).toEqual(
+      {
+        Items: {
+          L: [{ N: "0" }, { BOOL: false }, { NULL: true }, { S: "" }],
+        },
+      }
+    );
   });
 });
 
@@ -23,22 +23,20 @@ describe("marshallInput for commands", () => {
         },
       },
     };
-    const inputKeyNodes = [
-      {
-        key: "KeyConditions",
-        children: {
-          children: [{ key: "AttributeValueList", children: {} }],
+    const inputKeyNodes = {
+      KeyConditions: {
+        "*": {
+          AttributeValueList: [],
         },
       },
-      {
-        key: "QueryFilter",
-        children: {
-          children: [{ key: "AttributeValueList" }],
+      QueryFilter: {
+        "*": {
+          AttributeValueList: null,
         },
       },
-      { key: "ExclusiveStartKey" },
-      { key: "ExpressionAttributeValues" },
-    ];
+      ExclusiveStartKey: null,
+      ExpressionAttributeValues: null,
+    };
     const output = {
       TableName: "TestTable",
       KeyConditions: { id: { AttributeValueList: [{ S: "test" }], ComparisonOperator: "EQ" } },
@@ -55,7 +53,9 @@ describe("marshallInput for commands", () => {
                         WHERE contains("col_1", ?)`,
       Parameters: ["some_param"],
     };
-    const inputKeyNodes = [{ key: "Parameters", children: {} }];
+    const inputKeyNodes = {
+      Parameters: [],
+    };
     const output = {
       Statement: input.Statement,
       Parameters: [{ S: "some_param" }],
@@ -76,14 +76,13 @@ describe("marshallInput for commands", () => {
         },
       ],
     };
-    const inputKeyNodes = [
-      {
-        key: "Statements",
-        children: {
-          children: [{ key: "Parameters", children: {} }],
+    const inputKeyNodes = {
+      Statements: {
+        "*": {
+          Parameters: [],
         },
       },
-    ];
+    };
     const output = {
       Statements: [
         {

--- a/lib/lib-dynamodb/src/commands/utils.spec.ts
+++ b/lib/lib-dynamodb/src/commands/utils.spec.ts
@@ -9,46 +9,63 @@ describe("utils", () => {
   const testCases = [
     {
       testName: "single key",
-      keyNodes: [{ key: "Item", children: {} }],
+      keyNodes: { Item: {} },
       nativeAttrObj: { Item: nativeAttrValue(1), ...notAttrValue },
       attrObj: { Item: attrValue(1), ...notAttrValue },
     },
     {
       testName: "multiple keys",
-      keyNodes: [
-        { key: "Item1", children: {} },
-        { key: "Item2", children: {} },
-      ],
+      keyNodes: { Item1: {}, Item2: {} },
       nativeAttrObj: { Item1: nativeAttrValue(1), Item2: nativeAttrValue(2), ...notAttrValue },
       attrObj: { Item1: attrValue(1), Item2: attrValue(2), ...notAttrValue },
     },
     {
       testName: "array",
-      keyNodes: [{ key: "Items", children: { children: {} } }],
+      keyNodes: { Items: { "*": {} } },
       nativeAttrObj: { Items: [nativeAttrValue(1), nativeAttrValue(2)], ...notAttrValue },
       attrObj: { Items: [attrValue(1), attrValue(2)], ...notAttrValue },
     },
     {
       testName: "secondary level",
-      keyNodes: [{ key: "Parent", children: [{ key: "Item", children: {} }] }],
+      keyNodes: {
+        Parent: {
+          Item: {},
+        },
+      },
       nativeAttrObj: { Parent: { Item: nativeAttrValue(1), ...notAttrValue }, ...notAttrValue },
       attrObj: { Parent: { Item: attrValue(1), ...notAttrValue }, ...notAttrValue },
     },
     {
       testName: "secondary level array",
-      keyNodes: [{ key: "Parent", children: [{ key: "Items", children: { children: {} } }] }],
+      keyNodes: {
+        Parent: {
+          Items: {
+            "*": [],
+          },
+        },
+      },
       nativeAttrObj: { Parent: { Items: [nativeAttrValue(1), nativeAttrValue(2)], ...notAttrValue }, ...notAttrValue },
       attrObj: { Parent: { Items: [attrValue(1), attrValue(2)], ...notAttrValue }, ...notAttrValue },
     },
     {
       testName: "all entries",
-      keyNodes: [{ key: "Parent", children: { children: {} } }],
+      keyNodes: {
+        Parent: {
+          "*": {},
+        },
+      },
       nativeAttrObj: { Parent: { key1: nativeAttrValue(1), key2: nativeAttrValue(2) }, ...notAttrValue },
       attrObj: { Parent: { key1: attrValue(1), key2: attrValue(2) }, ...notAttrValue },
     },
     {
       testName: "all entries single key",
-      keyNodes: [{ key: "Parent", children: { children: [{ key: "Item", children: {} }] } }],
+      keyNodes: {
+        Parent: {
+          "*": {
+            Item: {},
+          },
+        },
+      },
       nativeAttrObj: {
         Parent: {
           key1: { Item: nativeAttrValue(1), ...notAttrValue },
@@ -66,17 +83,14 @@ describe("utils", () => {
     },
     {
       testName: "all entries multiple keys",
-      keyNodes: [
-        {
-          key: "Parent",
-          children: {
-            children: [
-              { key: "Item1", children: {} },
-              { key: "Item2", children: {} },
-            ],
+      keyNodes: {
+        Parent: {
+          "*": {
+            Item1: {},
+            Item2: {},
           },
         },
-      ],
+      },
       nativeAttrObj: {
         Parent: {
           key1: { Item1: nativeAttrValue(1), Item2: nativeAttrValue(2), ...notAttrValue },
@@ -94,7 +108,15 @@ describe("utils", () => {
     },
     {
       testName: "all entries array",
-      keyNodes: [{ key: "Parent", children: { children: [{ key: "Items", children: { children: {} } }] } }],
+      keyNodes: {
+        Parent: {
+          "*": {
+            Items: {
+              "*": [],
+            },
+          },
+        },
+      },
       nativeAttrObj: {
         Parent: {
           key1: { Items: [nativeAttrValue(1), nativeAttrValue(2)], ...notAttrValue },

--- a/packages/middleware-sdk-s3/src/s3Configuration.ts
+++ b/packages/middleware-sdk-s3/src/s3Configuration.ts
@@ -1,6 +1,6 @@
 /**
  * @public
- * 
+ *
  * All endpoint parameters with built-in bindings of AWS::S3::*
  */
 export interface S3InputConfig {
@@ -17,6 +17,8 @@ export interface S3InputConfig {
    * Whether multi-region access points (MRAP) should be disabled.
    */
   disableMultiregionAccessPoints?: boolean;
+
+  // bucketEndpoint boolean
 }
 
 export interface S3ResolvedConfig {


### PR DESCRIPTION
### Issue
modifies https://github.com/aws/aws-sdk-js-v3/pull/5306

### Description
generates the keyNodes instructional structure with a different, more readable format

before:
```ts
  protected readonly inputKeyNodes = [
    {
      key: "Item",
      children: {}, // map with AttributeValue
    },
    {
      key: "Expected",
      children: {
        children: [
          { key: "Value" },
          {
            key: "AttributeValueList",
            children: {}, // set/list of AttributeValue
          },
        ],
      },
    },
    {
      key: "ExpressionAttributeValues",
      children: {}, // map with AttributeValue
    },
  ];
  protected readonly outputKeyNodes = [
    {
      key: "Attributes",
      children: {}, // map with AttributeValue
    },
    {
      key: "ItemCollectionMetrics",
      children: [
        {
          key: "ItemCollectionKey",
          children: {}, // map with AttributeValue
        },
      ],
    },
  ];
```

after:
```ts
  protected readonly inputKeyNodes = {
    Item: ALL_VALUES, // map with AttributeValue
    Expected: {
      "*": {
        Value: SELF,
        AttributeValueList: ALL_MEMBERS, // set/list of AttributeValue
      },
    },
    ExpressionAttributeValues: ALL_VALUES, // map with AttributeValue
  };
  protected readonly outputKeyNodes = {
    Attributes: ALL_VALUES, // map with AttributeValue
    ItemCollectionMetrics: {
      ItemCollectionKey: ALL_VALUES, // map with AttributeValue
    },
  };
```

- [x] dynamodb e2e still passing
- [x] unit tests updated
